### PR TITLE
Added the ability to serve an error file if requested file not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Enable or disable setting for generate ETag. if true and if-none-match header ma
 ### extensions (string[] | undefined)
 Default: undefined;<br>
 Set file extension fallbacks. When set, if a file is not found, the given extensions will be added to the file name and search for. The first that exists will be served. Example: ['html', 'htm']. example: url /foo will force to file foo.html or foo.htm.
+### errorFile (string | boolean)
+Default: undefined;<br>
+Set default file on error. When set, if a file is not found, an error file is served.
 ### fallthrough (boolean)
 Default: true;<br>
 Set the middleware to have client errors fall-through as just unhandled requests, otherwise forward a client error. The difference is that client errors like a bad request or a request to a non-existent file will cause this middleware to simply next() to your next middleware when this value is true. When this value is false, these errors (even 404s), will invoke next(err).

--- a/mod.ts
+++ b/mod.ts
@@ -16,6 +16,12 @@ export default function staticFiles(root: string = "", opts: TOptions = {}) {
     root = root.substring(1);
   }
   opts.index = opts.index || "index.html";
+  opts.errorFile =
+    opts.errorFile === true
+      ? "index.html"
+      : typeof opts.errorFile === "string"
+      ? opts.errorFile
+      : undefined;
   opts.maxAge = opts.maxAge || 0;
   // true default
   opts.fallthrough = opts.fallthrough !== false;
@@ -60,7 +66,9 @@ export default function staticFiles(root: string = "", opts: TOptions = {}) {
     } catch (err) {
       let exts = fromExtensions(req, opts);
       if (exts) {
-        let stats: any, i = 0, len = exts.length;
+        let stats: any,
+          i = 0,
+          len = exts.length;
         for (; i < len; i++) {
           const ext = exts[i];
           const newPathFile = pathFile + "." + ext;
@@ -75,11 +83,40 @@ export default function staticFiles(root: string = "", opts: TOptions = {}) {
             const _body = await sendFile(stats.pathFile, opts, req, res, next);
             return _body;
           } catch (_err) {
+            if (typeof opts.errorFile === "string")
+              try {
+                const _body = await sendFile(
+                  join(rootPath, opts.errorFile),
+                  opts,
+                  req,
+                  res,
+                  next
+                );
+                return _body;
+              } catch {
+                // Do nothing...
+              }
+
             if (!opts.fallthrough) return next(_err);
             return next();
           }
         }
       }
+
+      if (typeof opts.errorFile === "string")
+        try {
+          const _body = await sendFile(
+            join(rootPath, opts.errorFile),
+            opts,
+            req,
+            res,
+            next
+          );
+          return _body;
+        } catch {
+          // Do nothing...
+        }
+
       if (!opts.fallthrough) return next(err);
       return next();
     }

--- a/mod.ts
+++ b/mod.ts
@@ -48,7 +48,8 @@ export default function staticFiles(root: string = "", opts: TOptions = {}) {
         "Matching Static:",
         req.url,
         opts.prefix,
-        req.url.includes(opts.prefix)
+        req.url.includes(opts.prefix),
+        typeof req.url
       );
       
       if (req.url.includes(opts.prefix)) {

--- a/mod.ts
+++ b/mod.ts
@@ -44,19 +44,13 @@ export default function staticFiles(root: string = "", opts: TOptions = {}) {
     const res = args[0];
     const next = args[1] || args[0] || ((err?: any) => _next(req, res, err));
     if (opts.prefix) {
-      console.log(
-        "Matching Static:",
-        req.url,
-        opts.prefix,
-        req.url.includes(opts.prefix),
-        typeof req.url
-      );
-      
-      if (req.url.includes(opts.prefix)) {
+      if (
+        new RegExp(`^${opts.prefix.split("/").filter(Boolean).join("/")}`).test(
+          req.url.split("/").filter(Boolean).join("/")
+        )
+      )
         req.url = req.url.substring(opts.prefix.length);
-      } else {
-        return next();
-      }
+      else return next();
     }
     if (req.method && req.method !== "GET" && req.method !== "HEAD") {
       if (opts.fallthrough) return next();

--- a/mod.ts
+++ b/mod.ts
@@ -44,6 +44,13 @@ export default function staticFiles(root: string = "", opts: TOptions = {}) {
     const res = args[0];
     const next = args[1] || args[0] || ((err?: any) => _next(req, res, err));
     if (opts.prefix) {
+      console.log(
+        "Matching Static:",
+        req.url,
+        opts.prefix,
+        req.url.includes(opts.prefix)
+      );
+      
       if (req.url.includes(opts.prefix)) {
         req.url = req.url.substring(opts.prefix.length);
       } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type TOptions = {
   maxAge?: number;
   index?: string;
   prefix?: string;
+  errorFile?: string | boolean;
   fallthrough?: boolean;
   etag?: boolean;
   extensions?: string[];


### PR DESCRIPTION
1. Some applications like react handle the URLs on the client side. If a file has not been found react returns a 404 error page on the client! So if a file has not been found on the server, it should just return index.html so that react can handle the error.
2. Redirects from other locations to an app like react (which handles URLs on the client side) would also work correctly!